### PR TITLE
Feature: `local` deployment strategy (GO support)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/golang/protobuf v1.4.1
+	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -74,7 +74,6 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -150,6 +149,7 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -190,8 +190,6 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.7.0 h1:xVKxvI7ouOI5I+U9s2eeiUfMaWBVoXA3AWskkrqK0VM=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
-github.com/spotsie/proto-domain-go v0.0.0-20201117135738-ba56e57b29c4 h1:ZXMLGjnXtQkMvXoVdiqAY8yYvNj7uCTqm/XmKdaA90Y=
-github.com/spotsie/proto-gateway-go v0.0.0-20210116132146-bf020d16f1c2 h1:Kagy9YUxO4LgPPrq1NcUkaMc2w4Pl7jqlTuYO2TKhss=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -296,7 +294,6 @@ golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc h1:NCy3Ohtk6Iny5V/reW2Ktypo4zIpWBdRJ1uFMjBxdg8=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/internal/distribute/distribute.go
+++ b/internal/distribute/distribute.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Distribute proto to files
-func Distribute(gitCfg git.Config, protoOutDir string, dryRun bool) {
+func Distribute(gitCfg git.Config, protoOutDir string, dryRun bool, deployTarget string, deployDir string) {
 	if dryRun {
 		fmt.Println("Dry run. Changes won't be pushed to GIT.")
 	}
@@ -39,10 +39,18 @@ func Distribute(gitCfg git.Config, protoOutDir string, dryRun bool) {
 	cloneBranch := "master"
 
 	// if ref is a branch, then the new branch will be created or checked out with the same branch name of the ref
-	if refType, refValue := gitCfg.ParseRef(); refType == "branch" {
-		cloneBranch = refValue
+	if deployTarget == "git" {
+		if refType, refValue := gitCfg.ParseRef(); refType == "branch" {
+			cloneBranch = refValue
+		}
 	}
-	target.Golang(protoOutDir, gitCfg, cloneBranch, cloneDir, dryRun)
-	target.Javascript(protoOutDir, gitCfg, cloneBranch, cloneDir, dryRun)
-	target.C(protoOutDir, gitCfg, cloneBranch, cloneDir, dryRun)
+
+	if deployTarget == "local" {
+		target.Golang(protoOutDir, gitCfg, cloneBranch, cloneDir, dryRun, deployTarget, deployDir)
+	} else {
+		target.Golang(protoOutDir, gitCfg, cloneBranch, cloneDir, dryRun, deployTarget, deployDir)
+		target.Javascript(protoOutDir, gitCfg, cloneBranch, cloneDir, dryRun, deployTarget, deployDir)
+		target.C(protoOutDir, gitCfg, cloneBranch, cloneDir, dryRun, deployTarget, deployDir)
+	}
+
 }

--- a/internal/target/c.go
+++ b/internal/target/c.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 )
 
-func C(protoOutDir string, gitCfg git.Config, cloneBranch string, cloneDir string, dryRun bool) {
+func C(protoOutDir string, gitCfg git.Config, cloneBranch string, cloneDir string, dryRun bool, deployTarget string, deployDir string) {
 	filterPackages := []string{"gateway"}
 	var scannedPackages []string
 

--- a/internal/target/javascript.go
+++ b/internal/target/javascript.go
@@ -10,7 +10,7 @@ import (
 	"path"
 )
 
-func Javascript(protoOutDir string, gitCfg git.Config, cloneBranch string, cloneDir string, dryRun bool) {
+func Javascript(protoOutDir string, gitCfg git.Config, cloneBranch string, cloneDir string, dryRun bool, deployTarget string, deployDir string) {
 	var tsPackages []string
 
 	repoName := "proto-all-js"


### PR DESCRIPTION
Use param --deploy to specify `git` or `local` strategy.
`local` deploy strategy generates go modules, links dependencies with the `replace` directive and saves them locally. This is useful for local development as you don't have to commit your working changes to the GIT repo.